### PR TITLE
feature: fetch docs from ES and save named in ES

### DIFF
--- a/datashare-spacy-worker/poetry.lock
+++ b/datashare-spacy-worker/poetry.lock
@@ -635,6 +635,28 @@ graph = ["objgraph (>=1.7.2)"]
 profile = ["gprof2dot (>=2022.7.29)"]
 
 [[package]]
+name = "elasticsearch"
+version = "7.17.12"
+description = "Python client for Elasticsearch"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<4,>=2.7"
+files = [
+    {file = "elasticsearch-7.17.12-py2.py3-none-any.whl", hash = "sha256:468fd5eef703c0d9238e29bcaf3a6fe4d6b092f917959fbf41f48f8fea3df2f8"},
+    {file = "elasticsearch-7.17.12.tar.gz", hash = "sha256:a1f5733ae8cf1dbf0a78593389f2503c87dd97429976099832bf0626cdfaac8b"},
+]
+
+[package.dependencies]
+aiohttp = {version = ">=3,<4", optional = true, markers = "extra == \"async\""}
+certifi = "*"
+urllib3 = ">=1.21.1,<2"
+
+[package.extras]
+async = ["aiohttp (>=3,<4)"]
+develop = ["black", "coverage", "jinja2", "mock", "pytest", "pytest-cov", "pyyaml", "requests (>=2.0.0,<3.0.0)", "sphinx (<1.7)", "sphinx-rtd-theme"]
+docs = ["sphinx (<1.7)", "sphinx-rtd-theme"]
+requests = ["requests (>=2.4.0,<3.0.0)"]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.2"
 description = "Backport of PEP 654 (exception groups)"
@@ -840,19 +862,22 @@ typing = ["types-PyYAML", "types-requests", "types-simplejson", "types-toml", "t
 
 [[package]]
 name = "icij-common"
-version = "0.5.1"
+version = "0.5.2"
 description = "Common utils for ICIJ libs"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "icij_common-0.5.1-py3-none-any.whl", hash = "sha256:8d23210fc56e3c437a6e4ece828348f2fa56b6b8a6015834b05297d327a219c6"},
-    {file = "icij_common-0.5.1.tar.gz", hash = "sha256:36e1de14d87f41b93701e6b9d7969184043f332fd563d77a5a8fc8fa495cb573"},
+    {file = "icij_common-0.5.2-py3-none-any.whl", hash = "sha256:6bf4bafe1e078ea51011f576cfc6bf625059103665d9465f002622a8f4e5b612"},
+    {file = "icij_common-0.5.2.tar.gz", hash = "sha256:022560bb90a714f35e5d3cc8e29f769f88910f3c54c376f3440672a3eb13b44b"},
 ]
 
 [package.dependencies]
+elasticsearch = {version = ">=7.17.9,<8.0.0", extras = ["async"], optional = true, markers = "extra == \"elasticsearch\""}
 pydantic = ">=1.10,<2.0"
+tenacity = {version = ">=9.0.0,<10.0.0", optional = true, markers = "extra == \"elasticsearch\""}
 
 [package.extras]
+elasticsearch = ["elasticsearch[async] (>=7.17.9,<8.0.0)", "tenacity (>=9.0.0,<10.0.0)"]
 fastapi = ["fastapi (>=0.99,<0.111)"]
 neo4j = ["neo4j (>=5.0.0,<6.0.0)"]
 
@@ -1771,6 +1796,17 @@ files = [
 typing-extensions = ">=4.6"
 
 [[package]]
+name = "pycountry"
+version = "24.6.1"
+description = "ISO country, subdivision, language, currency and script definitions and their translations"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycountry-24.6.1-py3-none-any.whl", hash = "sha256:f1a4fb391cd7214f8eefd39556d740adcc233c778a27f8942c8dca351d6ce06f"},
+    {file = "pycountry-24.6.1.tar.gz", hash = "sha256:b61b3faccea67f87d10c1f2b0fc0be714409e8fcdcc1315613174f6466c10221"},
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 description = "C parser in Python"
@@ -2296,23 +2332,23 @@ torch = ["safetensors[numpy]", "torch (>=1.10)"]
 
 [[package]]
 name = "setuptools"
-version = "74.0.0"
+version = "75.5.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "setuptools-74.0.0-py3-none-any.whl", hash = "sha256:0274581a0037b638b9fc1c6883cc71c0210865aaa76073f7882376b641b84e8f"},
-    {file = "setuptools-74.0.0.tar.gz", hash = "sha256:a85e96b8be2b906f3e3e789adec6a9323abf79758ecfa3065bd740d81158b11e"},
+    {file = "setuptools-75.5.0-py3-none-any.whl", hash = "sha256:87cb777c3b96d638ca02031192d40390e0ad97737e27b6b4fa831bea86f2f829"},
+    {file = "setuptools-75.5.0.tar.gz", hash = "sha256:5c4ccb41111392671f02bb5f8436dfc5a9a7185e80500531b133f5775c4163ef"},
 ]
 
 [package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)", "ruff (>=0.5.2)"]
-core = ["importlib-metadata (>=6)", "importlib-resources (>=5.10.2)", "jaraco.text (>=3.7)", "more-itertools (>=8.8)", "packaging (>=24)", "platformdirs (>=2.6.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)", "ruff (>=0.7.0)"]
+core = ["importlib-metadata (>=6)", "jaraco.collections", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more-itertools", "more-itertools (>=8.8)", "packaging", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
 enabler = ["pytest-enabler (>=2.2)"]
-test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib-metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.11.*)", "pytest-mypy"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
+type = ["importlib-metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (>=1.12,<1.14)", "pytest-mypy"]
 
 [[package]]
 name = "shellingham"
@@ -2697,6 +2733,21 @@ mpmath = ">=1.1.0,<1.4"
 
 [package.extras]
 dev = ["hypothesis (>=6.70.0)", "pytest (>=7.1.0)"]
+
+[[package]]
+name = "tenacity"
+version = "9.0.0"
+description = "Retry code until it succeeds"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539"},
+    {file = "tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b"},
+]
+
+[package.extras]
+doc = ["reno", "sphinx"]
+test = ["pytest", "tornado (>=4.5)", "typeguard"]
 
 [[package]]
 name = "thinc"
@@ -3232,20 +3283,19 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.2"
+version = "1.26.20"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.8"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 files = [
-    {file = "urllib3-2.2.2-py3-none-any.whl", hash = "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"},
-    {file = "urllib3-2.2.2.tar.gz", hash = "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"},
+    {file = "urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e"},
+    {file = "urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
-h2 = ["h2 (>=4,<5)"]
-socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "wasabi"
@@ -3471,4 +3521,4 @@ transformers = ["spacy-curated-transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a62a279cfe2f403fb7cf96ba9d852be18b7dc138d3c46305d43e27c186885379"
+content-hash = "cf69d82868bdd551bbd7b308027cca2b73afb6cf4226ee1b2bf22d0b662b6fbc"

--- a/datashare-spacy-worker/pyproject.toml
+++ b/datashare-spacy-worker/pyproject.toml
@@ -14,6 +14,7 @@ where = ["spacy_worker/data/*.json"]
 python = "^3.10"
 
 icij-worker = { extras = ["amqp"], version = "^0.11.7" }
+icij-common = { extras = ["elasticsearch"], version = "^0.5.2" }
 # TODO: it seems that wheels are not built for spacy >= 3.7.6 for ARM
 # TODO: optionnally add CUDA support for when a GPU is available
 spacy = [
@@ -24,6 +25,8 @@ spacy = [
 ]
 spacy-curated-transformers = { version = "^0.2.2", optional = true }
 
+pycountry = "^24.6.1"
+setuptools = "^75.5.0"
 [tool.poetry.extras]
 transformers = [
     "spacy-curated-transformers"
@@ -43,5 +46,5 @@ build-backend = "poetry.core.masonry.api"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 markers = [
-    "pretest: test which will run before unit test",
+    "integration: integration test",
 ]

--- a/datashare-spacy-worker/spacy_worker/app.py
+++ b/datashare-spacy-worker/spacy_worker/app.py
@@ -1,9 +1,7 @@
-from typing import Dict, List, Optional
-
 from icij_worker import AsyncApp
 from icij_worker.typing_ import RateProgress
 
-from spacy_worker.tasks import spacy_ner as spacy_ner_
+from spacy_worker.tasks import spacy_ner_task as spacy_ner_
 from spacy_worker.tasks.dependencies import APP_LIFESPAN_DEPS
 
 app = AsyncApp("spacy", dependencies=APP_LIFESPAN_DEPS)
@@ -11,12 +9,17 @@ app = AsyncApp("spacy", dependencies=APP_LIFESPAN_DEPS)
 
 @app.task(name="spacy-ner")
 async def spacy_ner(
-    texts: List[str],
-    language: str,
+    docs: list[dict],
+    categories: list[str] = None,
     *,
-    categories: List[str] = None,
-    progress: Optional[RateProgress] = None,
-) -> List[List[Dict]]:
+    model_size: str | None = None,
+    max_length: int,
+    progress: RateProgress | None = None,
+) -> int:
     return await spacy_ner_(
-        texts, language=language, categories=categories, progress=progress
+        docs,
+        categories=categories,
+        model_size=model_size,
+        progress=progress,
+        max_length=max_length,
     )

--- a/datashare-spacy-worker/spacy_worker/config.py
+++ b/datashare-spacy-worker/spacy_worker/config.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, List
+from typing import ClassVar
 
 from icij_common.pydantic_utils import ICIJSettings, NoEnumModel
 from icij_worker.utils.logging_ import LogWithWorkerIDMixin
@@ -14,13 +14,46 @@ class AppConfig(ICIJSettings, LogWithWorkerIDMixin, NoEnumModel):
     class Config:
         env_prefix = "DS_DOCKER_SPACY_"
 
-    loggers: ClassVar[List[str]] = Field(_ALL_LOGGERS, const=True)
+    loggers: ClassVar[list[str]] = Field(_ALL_LOGGERS, const=True)
 
     log_level: str = Field(default="INFO")
 
     batch_size: int = 1024
-    max_processes: int = -1
+    pipeline_batch_size: int = 1024
+    ne_buffer_size: int = 1000
+
+    # DS
+    ds_api_key: str | None = None
+    # ES
+    es_address: str = "http://localhost:9200"
+    es_default_page_size: int = 1000
+    es_keep_alive: str = "10m"
+    es_max_concurrency: int = 5
+    es_max_retries: int = 0
+    es_max_retry_wait_s: int | float = 60
+    es_timeout_s: int | float = 60 * 5
+
+    max_processes: int = 1
     max_languages_in_memory: int = 2
 
     def to_provider(self) -> SpacyProvider:
         return SpacyProvider(self.max_languages_in_memory)
+
+    def to_es_client(self, address: str | None = None) -> "ESClient":
+        from icij_common.es import ESClient
+
+        if address is None:
+            address = self.es_address
+
+        client = ESClient(
+            hosts=[address],
+            pagination=self.es_default_page_size,
+            max_concurrency=self.es_max_concurrency,
+            keep_alive=self.es_keep_alive,
+            timeout=self.es_timeout_s,
+            max_retries=self.es_max_retries,
+            max_retry_wait_s=self.es_max_retry_wait_s,
+            api_key=self.ds_api_key,
+        )
+        client.transport._verified_elasticsearch = True
+        return client

--- a/datashare-spacy-worker/spacy_worker/core.py
+++ b/datashare-spacy-worker/spacy_worker/core.py
@@ -3,34 +3,23 @@ from __future__ import annotations
 import json
 import logging
 from functools import lru_cache
-from typing import (
-    Any,
-    Collection,
-    Dict,
-    Generator,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Set,
-    Tuple,
-)
+from typing import Any, Generator, Iterable, Iterator
 
 import spacy
 from icij_worker.typing_ import RateProgress
 from icij_worker.utils.progress import to_raw_progress
-from spacy import Language
+from spacy import Language as SpacyLanguage
 from spacy.cli import download
 from spacy.tokens import Doc as SpacyDoc, Span
 from spacy.util import is_package
 
 from spacy_worker.constants import DATA_DIR
 from spacy_worker.ner_label_scheme import NERLabelScheme
-from spacy_worker.objects import Category, NamedEntity, SpacySize
+from spacy_worker.objects import Category, NlpTag, SpacySize
 
 logger = logging.getLogger(__name__)
 
-DocCtx = Dict[str, Any]
+DocCtx = dict[str, Any]
 _DEFAULT_EXCLUDE = [
     "tagger",
     "morphologizer",
@@ -42,23 +31,25 @@ _DEFAULT_EXCLUDE = [
 
 
 async def spacy_ner(
-    texts: Collection[str],
-    ner: Language,
+    text: list[str],
+    ner: SpacyLanguage,
     *,
-    categories: Set[Category],
-    sent_split: Language,
+    categories: list[Category],
+    sent_split: SpacyLanguage,
     n_process: int = -1,
-    batch_size: Optional[int],
-    progress: Optional[RateProgress] = None,
-) -> Generator[List[NamedEntity], None, None]:
+    batch_size: int | None,
+    progress: RateProgress | None = None,
+) -> Generator[list[NlpTag], None, None]:
+    categories = set(categories)
     if progress is not None:
-        progress = to_raw_progress(progress, max_progress=len(texts))
+        progress = to_raw_progress(progress, max_progress=len(text))
     label_scheme = NERLabelScheme(tuple(ner.pipe_labels.get("ner")))
     # TODO: for better NER performance, it could be nicer have chunks for several
     #  sentence rather than just sentence by sentence
-    split_texts = _split_docs_spacy(texts, sent_split)
+    split_texts = _split_docs_spacy(text, sent_split)
     previous_ctx = None
     sub_docs = []
+    logger.debug("creating spacy pipe with %s process(es)", n_process)
     pipe = ner.pipe(
         split_texts, n_process=n_process, as_tuples=True, batch_size=batch_size
     )
@@ -68,12 +59,11 @@ async def spacy_ner(
     for doc, ctx in pipe:
         if previous_ctx is not None and ctx["doc_ix"] != previous_ctx["doc_ix"]:
             merged = _merge_subdocs(sub_docs)
-            predicted = _spacy_doc_to_ds_named_entities(
-                merged, categories, label_scheme
-            )
+            predicted = _spacy_doc_to_ds_tags(merged, categories, label_scheme)
             yield predicted
             n_processed_texts += 1
-            if progress is not None:
+            update_progress = not (ctx["doc_ix"] % 50)
+            if progress is not None and update_progress:
                 await progress(n_processed_texts)
             sub_docs = [doc]
         else:
@@ -81,7 +71,7 @@ async def spacy_ner(
         previous_ctx = ctx
     if sub_docs:
         merged = _merge_subdocs(sub_docs)
-        predicted = _spacy_doc_to_ds_named_entities(merged, categories, label_scheme)
+        predicted = _spacy_doc_to_ds_tags(merged, categories, label_scheme)
         yield predicted
         n_processed_texts += 1
         if progress is not None:
@@ -103,21 +93,21 @@ class SpacyProvider:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self._pipelines.clear()
 
-    def get_ner(self, language: str, *, size: SpacySize) -> Language:
-        return self._load_nlp(language, size=size)
+    def get_ner(self, language: str, *, model_size: SpacySize) -> SpacyLanguage:
+        return self._load_nlp(language, model_size=model_size)
 
-    def get_sent_split(self, language: str) -> Language:
-        vocab = self._load_nlp(language, size=SpacySize.SMALL).vocab
+    def get_sent_split(self, language: str, *, model_size: SpacySize) -> SpacyLanguage:
+        vocab = self._load_nlp(language, model_size=model_size).vocab
         sent_split = spacy.blank(language, vocab=vocab)
         sent_split.add_pipe("sentencizer")
         return sent_split
 
-    def _load_nlp(self, language: str, *, size: SpacySize) -> Language:
+    def _load_nlp(self, language: str, *, model_size: SpacySize) -> SpacyLanguage:
         # pylint: disable=method-hidden
         logger.debug("loading spacy for %s...", language)
-        size = size.value
-        model = self._models[language]["sizes"][size]
-        model_name = f"{language}_{model['model']}_{size}"
+        model_size = model_size.value
+        model = self._models[language]["sizes"][model_size]
+        model_name = f"{language}_{model['model']}_{model_size}"
         # TODO: use GPU acceleration using spacy.prefer_gpu() + spacy[cuda]
         # TODO: check if we can exclude globally or we must do it language per langauge
         exclude = model.get("exclude", _DEFAULT_EXCLUDE)
@@ -127,35 +117,34 @@ class SpacyProvider:
         return spacy.load(model_name, exclude=exclude)
 
 
-def _merge_subdocs(sub_docs: List[SpacyDoc]) -> SpacyDoc:
+def _merge_subdocs(sub_docs: list[SpacyDoc]) -> SpacyDoc:
     return SpacyDoc.from_docs(sub_docs, ensure_whitespace=False)
 
 
 def _split_docs_spacy(
-    docs: Iterable[str], sent_split: Language
-) -> Iterator[Tuple[SpacyDoc, DocCtx]]:
+    docs: Iterable[str], sent_split: SpacyLanguage
+) -> Iterator[tuple[SpacyDoc, DocCtx]]:
     inputs = ((doc, {"doc_ix": i}) for i, doc in enumerate(docs))
     return sent_split.pipe(inputs, as_tuples=True)
 
 
-def _spacy_doc_to_ds_named_entities(
-    doc: SpacyDoc, supported_categories: Set[Category], label_scheme: NERLabelScheme
-) -> List[NamedEntity]:
+def _spacy_doc_to_ds_tags(
+    doc: SpacyDoc, supported_categories: set[Category], label_scheme: NERLabelScheme
+) -> list[NlpTag]:
     ents = (
-        _spacy_doc_to_named_entity(ent, supported_categories, label_scheme)
+        _spacy_doc_to_ds_tag(ent, supported_categories, label_scheme)
         for ent in doc.ents
     )
     return [ent for ent in ents if ent is not None]
 
 
-def _spacy_doc_to_named_entity(
+def _spacy_doc_to_ds_tag(
     ent: Span,
-    supported_categories: Set[Category],
+    supported_categories: set[Category],
     label_scheme: NERLabelScheme,
-) -> Optional[NamedEntity]:
+) -> NlpTag | None:
     category = label_scheme.to_spacy(ent.label_)
     if category is None or category not in supported_categories:
         return None
     start = ent.start_char
-    end = ent.end_char
-    return NamedEntity(start=start, end=end, category=category)
+    return NlpTag(start=start, mention=ent.text, category=category)

--- a/datashare-spacy-worker/spacy_worker/ner_label_scheme.py
+++ b/datashare-spacy-worker/spacy_worker/ner_label_scheme.py
@@ -1,6 +1,5 @@
 from enum import Enum, EnumType, unique
 from functools import lru_cache
-from typing import Optional, Tuple
 
 from spacy_worker.objects import Category
 
@@ -98,12 +97,12 @@ class NERLabelScheme(tuple, Enum, metaclass=SortedValuesEnumMeta):
     RUSSIAN = _RUSSIAN
     SWEDISH = _SWEDISH
 
-    def __new__(cls, value: Tuple[str, ...]):
+    def __new__(cls, value: tuple[str, ...]):
         obj = super().__new__(cls, tuple(sorted(value)))
         return obj
 
     @lru_cache
-    def to_spacy(self, spacy_label: str) -> Optional[Category]:
+    def to_spacy(self, spacy_label: str) -> Category | None:
         match self:
             case NERLabelScheme.CONLL:
                 return conll_label_to_ds(spacy_label)
@@ -129,7 +128,7 @@ class NERLabelScheme(tuple, Enum, metaclass=SortedValuesEnumMeta):
                 raise ValueError(f"Unexpected value {self}")
 
 
-def conll_label_to_ds(label: str) -> Optional[Category]:
+def conll_label_to_ds(label: str) -> Category | None:
     match label:
         case "LOC":
             return Category.LOC
@@ -143,7 +142,7 @@ def conll_label_to_ds(label: str) -> Optional[Category]:
             raise ValueError(f"Unexpected value {label}")
 
 
-def croatian_slovenian_label_to_ds(label: str) -> Optional[Category]:
+def croatian_slovenian_label_to_ds(label: str) -> Category | None:
     match label:
         case "LOC":
             return Category.LOC
@@ -157,7 +156,7 @@ def croatian_slovenian_label_to_ds(label: str) -> Optional[Category]:
             raise ValueError(f"Unexpected value {label}")
 
 
-def greek_label_to_ds(label: str) -> Optional[Category]:
+def greek_label_to_ds(label: str) -> Category | None:
     match label:
         case "LOC" | "GPE" | "EVENT":
             return Category.LOC
@@ -171,7 +170,7 @@ def greek_label_to_ds(label: str) -> Optional[Category]:
             raise ValueError(f"Unexpected value {label}")
 
 
-def japanese_label_to_ds(label: str) -> Optional[Category]:
+def japanese_label_to_ds(label: str) -> Category | None:
     match label:
         case "LOC" | "GPE" | "FAC" | "EVENT":
             return Category.LOC
@@ -199,7 +198,7 @@ def japanese_label_to_ds(label: str) -> Optional[Category]:
             raise ValueError(f"Unexpected value {label}")
 
 
-def lithuanian_label_to_ds(label: str) -> Optional[Category]:
+def lithuanian_label_to_ds(label: str) -> Category | None:
     match label:
         case "LOC" | "GPE":
             return Category.LOC
@@ -215,7 +214,7 @@ def lithuanian_label_to_ds(label: str) -> Optional[Category]:
             raise ValueError(f"Unexpected value {label}")
 
 
-def norwegian_label_to_ds(label: str) -> Optional[Category]:
+def norwegian_label_to_ds(label: str) -> Category | None:
     match label:
         case "LOC" | "GPE_LOC" | "EVT":
             return Category.LOC
@@ -227,7 +226,7 @@ def norwegian_label_to_ds(label: str) -> Optional[Category]:
             return None
 
 
-def onto_notes_5_label_to_ds(label: str) -> Optional[Category]:
+def onto_notes_5_label_to_ds(label: str) -> Category | None:
     match label:
         case "LOC" | "GPE" | "FAC" | "EVENT":
             return Category.LOC
@@ -247,7 +246,7 @@ def onto_notes_5_label_to_ds(label: str) -> Optional[Category]:
             raise ValueError(f"Unexpected value {label}")
 
 
-def polish_label_to_ds(label: str) -> Optional[Category]:
+def polish_label_to_ds(label: str) -> Category | None:
     match label:
         case "date" | "time":
             return Category.DATE
@@ -261,7 +260,7 @@ def polish_label_to_ds(label: str) -> Optional[Category]:
             raise ValueError(f"Unexpected value {label}")
 
 
-def romanian_label_to_ds(label: str) -> Optional[Category]:
+def romanian_label_to_ds(label: str) -> Category | None:
     match label:
         case "LOC" | "GPE" | "FACILITY" | "EVENT":
             return Category.LOC
@@ -281,7 +280,7 @@ def romanian_label_to_ds(label: str) -> Optional[Category]:
             raise ValueError(f"Unexpected value {label}")
 
 
-def russian_label_to_ds(label: str) -> Optional[Category]:
+def russian_label_to_ds(label: str) -> Category | None:
     match label:
         case "LOC":
             return Category.LOC

--- a/datashare-spacy-worker/spacy_worker/objects.py
+++ b/datashare-spacy-worker/spacy_worker/objects.py
@@ -1,6 +1,31 @@
-from enum import Enum, unique
+from __future__ import annotations
 
-from icij_common.pydantic_utils import LowerCamelCaseModel
+import re
+from collections import defaultdict
+from enum import Enum, unique
+from hashlib import md5
+
+from icij_common.es import (
+    DOC_CONTENT,
+    DOC_CONTENT_LENGTH,
+    DOC_LANGUAGE,
+    DOC_ROOT_ID,
+    ID_,
+    SOURCE,
+)
+from icij_common.pydantic_utils import LowerCamelCaseModel, safe_copy
+from pydantic import Field, root_validator
+from typing_extensions import Self
+
+from spacy_worker.utils import lower_camel_to_snake_case
+
+
+@unique
+class SpacySize(str, Enum):
+    SMALL = "sm"
+    MEDIUM = "md"
+    LARGE = "lg"
+    TRANSFORMER = "trf"
 
 
 @unique
@@ -14,15 +39,116 @@ class Category(str, Enum):
     UNK = "UNKNOWN"
 
 
-class NamedEntity(LowerCamelCaseModel):
+class BatchDocument(LowerCamelCaseModel):
+    id: str
+    root_document: str
+    project: str
+    language: str
+
+    @classmethod
+    def from_es(cls, es_doc: dict, project: str) -> Self:
+        sources = es_doc[SOURCE]
+        return cls(
+            project=project,
+            id=es_doc[ID_],
+            root_id=sources[DOC_ROOT_ID],
+            language=sources[DOC_LANGUAGE],
+        )
+
+
+class Document(BatchDocument):
+    content: str
+    content_length: int
+
+    @classmethod
+    def from_es(cls, es_doc: dict, project: str) -> Self:
+        sources = es_doc[SOURCE]
+        return cls(
+            project=project,
+            id=es_doc[ID_],
+            root_id=sources[DOC_ROOT_ID],
+            language=sources[DOC_LANGUAGE],
+            content=sources[DOC_CONTENT],
+            content_length=sources[DOC_CONTENT_LENGTH],
+        )
+
+
+class NlpTag(LowerCamelCaseModel):
     start: int
-    end: int
+    mention: str
     category: Category
 
+    def with_offset(self, offset: int) -> Self:
+        return safe_copy(self, update={"start": self.start + offset})
 
-@unique
-class SpacySize(str, Enum):
-    SMALL = "sm"
-    MEDIUM = "md"
-    LARGE = "lg"
-    TRANSFORMER = "trf"
+
+SPACY_PIPELINE_NAME = "SPACY"
+_ID_PLACEHOLDER, _MENTION_NORM_PLACEHOLDER = "", ""
+
+
+class NamedEntity(LowerCamelCaseModel):
+    id: str = _ID_PLACEHOLDER
+    category: Category
+    mention: str
+    mention_norm: str = _ID_PLACEHOLDER
+    document_id: str
+    root_document: str
+    extractor: str = Field(default=SPACY_PIPELINE_NAME, const=True)
+    type: str = Field(default="NamedEntity", const=True)
+    extractor_language: str
+    offsets: list[int]
+
+    @root_validator(pre=True)
+    def generate_id(cls, values: dict) -> dict:
+        values = {lower_camel_to_snake_case(k): v for k, v in values.items()}
+        provided_mention_norm = values.get("mention_norm")
+        hasher = md5()
+        offsets = values.get("offsets", [])
+        offsets = sorted(offsets)
+        mention = values.get("mention", "")
+        mention_norm = _normalize(mention)
+        if provided_mention_norm is not None and provided_mention_norm != mention_norm:
+            msg = (
+                f'provided mention_norm ("{provided_mention_norm}") differs from '
+                f'computed mention norm ("{mention_norm}")'
+            )
+            raise ValueError(msg)
+        values["mention_norm"] = mention_norm
+        doc_id = values.get("document_id", "")
+        hashed = (doc_id, str(offsets), SPACY_PIPELINE_NAME, mention_norm)
+        for h in hashed:
+            hasher.update(h.encode())
+        ne_id = hasher.hexdigest()
+        provided_id = values.get("id")
+        if provided_id is not None and provided_id != ne_id:
+            msg = f'provided id ("{provided_id}") differs from computed id ("{ne_id}")'
+            raise ValueError(msg)
+        values["id"] = ne_id
+        return values
+
+    @classmethod
+    def from_tags(cls, tags: list[NlpTag], doc: BatchDocument) -> list[Self]:
+        entities = defaultdict(list)
+        for tag in tags:
+            entities[(tag.mention, tag.category)].append(tag.start)
+        ents = []
+        for (mention, category), offsets in entities.items():
+            ents.append(
+                NamedEntity(
+                    category=category,
+                    mention=mention,
+                    document_id=doc.id,
+                    root_document=doc.root_document,
+                    extractor_language=doc.language,
+                    offsets=offsets,
+                )
+            )
+        return ents
+
+
+_CONSECUTIVE_SPACES_RE = re.compile(r"\s+")
+
+
+def _normalize(s: str) -> str:
+    s = s.strip()
+    return _CONSECUTIVE_SPACES_RE.sub(" ", s).lower()

--- a/datashare-spacy-worker/spacy_worker/tasks/__init__.py
+++ b/datashare-spacy-worker/spacy_worker/tasks/__init__.py
@@ -1,45 +1,216 @@
+import functools
 import multiprocessing
-from typing import Dict, List, Optional
 
+import math
+import pycountry
+from elasticsearch._async.helpers import async_bulk
+from icij_common.es import DOC_CONTENT, DOC_LANGUAGE, ESClient, ID_
+from icij_common.pydantic_utils import jsonable_encoder
 from icij_worker.typing_ import RateProgress
+from icij_worker.utils.progress import to_raw_progress
+from pydantic import parse_obj_as
 from spacy import Language
+from spacy.tokens.doc import defaultdict
 
 from spacy_worker.core import spacy_ner as spacy_ner_
-from spacy_worker.objects import Category, SpacySize
-from spacy_worker.tasks.dependencies import lifespan_config, lifespan_spacy_provider
+from spacy_worker.objects import BatchDocument, Category, NamedEntity, NlpTag, SpacySize
+from spacy_worker.tasks.dependencies import (
+    lifespan_config,
+    lifespan_es_client,
+    lifespan_spacy_provider,
+)
 
 _DEFAULT_CATEGORIES = [Category.LOC, Category.PER, Category.ORG]
+_NE_SCHEMA = NamedEntity.schema(by_alias=True)
 
 
-async def spacy_ner(
-    texts: List[str],
-    language: str,
+async def spacy_ner_task(
+    docs: list[dict],
+    categories: list[str] = None,
     *,
-    categories: List[str] = None,
-    size: str = SpacySize.SMALL.value,
-    progress: Optional[RateProgress] = None,
-) -> List[List[Dict]]:
+    model_size: str,
+    max_length: int,
+    progress: RateProgress | None = None,
+) -> int:
+    if not docs:
+        return len(docs)
     if categories is None:
         categories = set(c.value for c in _DEFAULT_CATEGORIES)
     else:
         categories = set(Category(c) for c in categories)
+    docs = parse_obj_as(list[BatchDocument], docs)
+    if progress is not None:
+        progress = to_raw_progress(progress, max_progress=len(docs))
     config = lifespan_config()
+    es_client = lifespan_es_client()
+    # TODO: perform a NamedEntityModel check
     spacy_provider = lifespan_spacy_provider()
-    size = SpacySize(size)
-    ner = spacy_provider.get_ner(language, size=size)
-    sent_split = spacy_provider.get_sent_split(language)
+    model_size = SpacySize(model_size)
+    docs_language = docs[0].language
+    language = pycountry.languages.get(name=docs_language)
+    if language is None or not hasattr(language, "alpha_2"):
+        raise ValueError(f'Unknown language "{docs_language}"')
+    language = language.alpha_2
+    ner = spacy_provider.get_ner(language, model_size=model_size)
+    sent_split = spacy_provider.get_sent_split(language, model_size=model_size)
     n_process = get_n_process(ner, max_processes=config.max_processes)
-    entities_gen = spacy_ner_(
-        texts,
+    return await _process_docs(
+        docs,
         ner,
+        sent_split,
+        categories,
+        es_client,
+        pipeline_batch_size=config.pipeline_batch_size,
+        batch_size=config.batch_size,
+        ne_buffer_size=config.ne_buffer_size,
+        max_length=max_length,
+        n_process=n_process,
+        progress=progress,
+    )
+
+
+class _TagsBuffer:
+    def __init__(self, max_length: int):
+        self._max_length = max_length
+        self._batch_ix_to_doc_ix: dict[int, int] = dict()
+        self._n_doc_chunks: dict[int, int] = dict()
+        self._doc_tags: dict[int, list[list[NlpTag]]] = defaultdict(list)
+
+    def add_doc(self, i: int, doc: dict):
+        self._n_doc_chunks[i] = math.ceil(len(doc[DOC_CONTENT]) / self._max_length)
+
+    def add_batch_tags(self, batch_tags: list[list[NlpTag]]):
+        for tag_i, tags in enumerate(batch_tags):
+            chunks_tags = self._doc_tags[self._batch_ix_to_doc_ix[tag_i]]
+            offset = self._max_length * len(chunks_tags)
+            tags = [t.with_offset(offset) for t in tags]
+            chunks_tags.append(tags)
+        for doc_i, tags in self._doc_tags.items():
+            if len(tags) != self._n_doc_chunks[doc_i]:
+                continue
+        self._batch_ix_to_doc_ix.clear()
+
+    def set_batch_doc_ix(self, doc_ix: int):
+        new_ix = len(self._batch_ix_to_doc_ix)
+        self._batch_ix_to_doc_ix[new_ix] = doc_ix
+
+    def get_ready(self) -> dict[int, list[NlpTag]]:
+        ready = {
+            doc_i: sum(tags, start=[])
+            for doc_i, tags in self._doc_tags.items()
+            if len(tags) == self._n_doc_chunks[doc_i]
+        }
+        for doc_i in ready:
+            self._n_doc_chunks.pop(doc_i)
+            self._doc_tags.pop(doc_i)
+        return ready
+
+    def __len__(self):
+        return len(self._n_doc_chunks)
+
+
+async def _process_docs(
+    docs: list[BatchDocument],
+    ner,
+    sent_split,
+    categories: set[Category],
+    es_client: ESClient,
+    *,
+    batch_size: int,
+    pipeline_batch_size: int,
+    max_length: int,
+    ne_buffer_size: int,
+    n_process: int,
+    progress: RateProgress | None,
+):
+    batch = []
+    n_docs = len(docs)
+    if not n_docs:
+        return
+    project = docs[0].project
+    tags_buffer = _TagsBuffer(max_length)
+    ne_buffer = []
+    tag_fn = functools.partial(
+        spacy_ner_,
+        ner=ner,
         categories=categories,
         sent_split=sent_split,
         n_process=n_process,
-        progress=progress,
-        batch_size=config.batch_size,
+        progress=None,
+        batch_size=pipeline_batch_size,
     )
-    entities = [[e.dict() for e in ents] async for ents in entities_gen]
-    return entities
+    # Let's not overload the broker with events and only log progress halfway
+    progress_rate = len(docs) / 2
+    for doc_i, doc in enumerate(docs):
+        es_doc = await es_client.get_source(
+            index=doc.project,
+            id=doc.id,
+            routing=doc.root_document,
+            _source_includes=[DOC_LANGUAGE, DOC_CONTENT],
+        )
+        tags_buffer.add_doc(doc_i, es_doc)
+        doc_content = es_doc[DOC_CONTENT]
+        doc_length = len(doc_content)
+        for text_i in range(0, doc_length, max_length):
+            chunk = doc_content[text_i : text_i + max_length]
+            batch.append(chunk)
+            tags_buffer.set_batch_doc_ix(doc_i)
+            if len(batch) >= batch_size:
+                batch_tags = [text_tags async for text_tags in tag_fn(batch)]
+                ready_ents = await _update_and_consume_buffer(
+                    tags_buffer, batch_tags, docs
+                )
+                ne_buffer += ready_ents
+                if len(ne_buffer) >= ne_buffer_size:
+                    await _bulk_add_ne(es_client, ne_buffer, project=project)
+                    ne_buffer.clear()
+                batch.clear()
+        if progress is not None and not doc_i % progress_rate:
+            await progress(doc_i / n_docs)
+    if batch:
+        batch_tags = [text_tags async for text_tags in tag_fn(batch)]
+        ready_ents = await _update_and_consume_buffer(tags_buffer, batch_tags, docs)
+        if len(tags_buffer):
+            raise ValueError(
+                "inconsistent state: tags buffer was not empty processing all docs"
+            )
+        ne_buffer += ready_ents
+    if ne_buffer:
+        await _bulk_add_ne(es_client, ne_buffer, project=project)
+    return n_docs
+
+
+async def _update_and_consume_buffer(
+    tags_buffer: _TagsBuffer,
+    batch_tags: list[list[NlpTag]],
+    docs: list[BatchDocument],
+) -> list[list[NamedEntity]]:
+    tags_buffer.add_batch_tags(batch_tags)
+    ready_ents = sum(
+        (
+            NamedEntity.from_tags(tags, docs[ready_i])
+            for ready_i, tags in tags_buffer.get_ready().items()
+        ),
+        [],
+    )
+    return ready_ents
+
+
+async def _bulk_add_ne(
+    es_client: ESClient, named_entities: list[NamedEntity], project: str
+):
+    named_entities = jsonable_encoder(named_entities)
+    actions = (
+        {
+            "_op_type": "update",
+            "_index": project,
+            ID_: ne["id"],
+            "doc": ne,
+            "doc_as_upsert": True,
+        }
+        for ne in named_entities
+    )
+    await async_bulk(es_client, actions, raise_on_error=True, refresh="wait_for")
 
 
 def get_n_process(ner: Language, max_processes: int) -> int:
@@ -47,4 +218,4 @@ def get_n_process(ner: Language, max_processes: int) -> int:
         return 1
     if max_processes == -1:
         max_processes = multiprocessing.cpu_count()
-    return max_processes - 1  # For the sentence splitter
+    return max_processes

--- a/datashare-spacy-worker/spacy_worker/tasks/dependencies.py
+++ b/datashare-spacy-worker/spacy_worker/tasks/dependencies.py
@@ -2,6 +2,7 @@ import logging
 from multiprocessing import Pool
 from typing import Optional
 
+from icij_common.es import ESClient
 from icij_worker import WorkerConfig
 from icij_worker.utils.dependencies import DependencyInjectionError
 
@@ -10,8 +11,9 @@ from spacy_worker.core import SpacyProvider
 
 logger = logging.getLogger(__name__)
 
-_ASYNC_APP_CONFIG: Optional[AppConfig] = None
+_ASYNC_APP_CONFIG: AppConfig | None = None
 _SPACY_PROVIDER: Optional[Pool] = None
+_ES_CLIENT: ESClient | None = None
 
 
 def load_app_config(worker_config: WorkerConfig, **_):
@@ -58,8 +60,31 @@ def lifespan_spacy_provider() -> SpacyProvider:
     return _SPACY_PROVIDER
 
 
+async def es_client_enter(**_):
+    # pylint: disable=unnecessary-dunder-call
+    config = lifespan_config()
+    global _ES_CLIENT
+    _ES_CLIENT = config.to_es_client()
+    await _ES_CLIENT.__aenter__()
+
+
+async def es_client_exit(exc_type, exc_val, exc_tb):
+    # pylint: disable=unnecessary-dunder-call
+    await lifespan_es_client().__aexit__(exc_type, exc_val, exc_tb)
+    global _ES_CLIENT
+    _ES_CLIENT = None
+
+
+def lifespan_es_client() -> ESClient:
+    # pylint: disable=unnecessary-dunder-call
+    if _ES_CLIENT is None:
+        raise DependencyInjectionError("es client")
+    return _ES_CLIENT
+
+
 APP_LIFESPAN_DEPS = [
     ("loading async app configuration", load_app_config, None),
     ("loggers", setup_loggers, None),
     ("spacy provider", spacy_provider_enter, spacy_provider_exit),
+    ("elasticsearch client", es_client_enter, es_client_exit),
 ]

--- a/datashare-spacy-worker/spacy_worker/tests/conftest.py
+++ b/datashare-spacy-worker/spacy_worker/tests/conftest.py
@@ -1,16 +1,50 @@
 # pylint: disable=redefined-outer-name
+import asyncio
 from pathlib import Path
+from typing import AsyncGenerator, Generator, Iterator
 
 import pytest
+from elasticsearch._async.helpers import async_streaming_bulk
+from icij_common.es import DOC_ROOT_ID, ESClient, ES_DOCUMENT_TYPE, ID
 from icij_worker import AMQPWorkerConfig
 
 from spacy_worker.app import app
 from spacy_worker.config import AppConfig
+from spacy_worker.objects import BatchDocument, Document
+from spacy_worker.tasks import lifespan_es_client
+
+
+@pytest.fixture(scope="session")
+def event_loop(request) -> Iterator[asyncio.AbstractEventLoop]:
+    # pylint: disable=unused-argument
+    """Create an instance of the default event loop for each test case."""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()
+
+
+TEST_PROJECT = "test-project"
+
+_INDEX_BODY = {
+    "mappings": {
+        "properties": {
+            "type": {"type": "keyword"},
+            "documentId": {"type": "keyword"},
+            "join": {"type": "join", "relations": {"Document": "NamedEntity"}},
+        }
+    }
+}
 
 
 @pytest.fixture(scope="session")
 def test_app_config() -> AppConfig:
-    return AppConfig(log_level="DEBUG", max_processes=2)
+    return AppConfig(
+        log_level="DEBUG",
+        max_processes=1,
+        pipeline_batch_size=2,
+        batch_size=1,
+        ne_buffer_size=2,
+    )
 
 
 @pytest.fixture(scope="session")
@@ -28,9 +62,114 @@ def test_worker_config(test_app_config_path: Path) -> AMQPWorkerConfig:
 
 
 @pytest.fixture(scope="session")
-async def app_lifetime_deps(test_worker_config: AMQPWorkerConfig):
+async def app_lifetime_deps(event_loop, test_worker_config: AMQPWorkerConfig):
     worker_id = "test-worker-id"
     async with app.lifetime_dependencies(
         worker_config=test_worker_config, worker_id=worker_id
     ):
         yield
+
+
+@pytest.fixture(scope="session")
+async def es_test_client_session(app_lifetime_deps) -> ESClient:
+    es = lifespan_es_client()
+    await es.indices.delete(index="_all")
+    await es.indices.create(index=TEST_PROJECT, body=_INDEX_BODY)
+    return es
+
+
+@pytest.fixture()
+async def test_es_client(
+    es_test_client_session: ESClient,
+) -> ESClient:
+    es = es_test_client_session
+    await es.indices.delete(index="_all")
+    await es.indices.create(index=TEST_PROJECT, body=_INDEX_BODY)
+    return es
+
+
+@pytest.fixture()
+async def populate_es(
+    test_es_client: ESClient, doc_0: Document, doc_1: Document
+) -> list[Document]:
+    docs = [doc_0, doc_1]
+    async for _ in index_docs(test_es_client, docs=docs, index_name=TEST_PROJECT):
+        pass
+    return docs
+
+
+def index_docs_ops(
+    docs: list[Document], index_name: str
+) -> Generator[dict, None, None]:
+    for doc in docs:
+        op = {
+            "_op_type": "index",
+            "_index": index_name,
+        }
+        doc = doc.dict(by_alias=True)
+        op.update(doc)
+        op["_id"] = doc[ID]
+        op["routing"] = doc[DOC_ROOT_ID]
+        op["type"] = ES_DOCUMENT_TYPE
+        yield op
+
+
+async def index_docs(
+    client: ESClient, *, docs: list[Document], index_name: str = TEST_PROJECT
+) -> AsyncGenerator[dict, None]:
+    ops = index_docs_ops(docs, index_name)
+    # Let's wait to make this operation visible to the search
+    refresh = "wait_for"
+    async for res in async_streaming_bulk(client, actions=ops, refresh=refresh):
+        yield res
+
+
+@pytest.fixture(scope="session")
+def text_0() -> str:
+    return """In this first sentence I'm speaking about a person named Dan.
+
+Then later I'm speaking about Paris and Paris again
+
+To finish I'm speaking about a company named Intel.
+"""
+
+
+@pytest.fixture(scope="session")
+def text_1() -> str:
+    return "some short document"
+
+
+@pytest.fixture(scope="session")
+def doc_0(text_0: str) -> Document:
+    return Document(
+        id="doc-0",
+        project=TEST_PROJECT,
+        root_document="root-0",
+        language="ENGLISH",
+        content=text_0,
+        content_length=len(text_0),
+    )
+
+
+@pytest.fixture(scope="session")
+def doc_1(text_1: str) -> Document:
+    return Document(
+        id="doc-1",
+        project=TEST_PROJECT,
+        root_document="root-1",
+        language="ENGLISH",
+        content=text_1,
+        content_length=len(text_1),
+    )
+
+
+@pytest.fixture(scope="session")
+def batch_docs() -> list[BatchDocument]:
+    return [
+        BatchDocument(
+            id="doc-0", root_document="root-0", project=TEST_PROJECT, language="ENGLISH"
+        ),
+        BatchDocument(
+            id="doc-1", root_document="root-1", project=TEST_PROJECT, language="ENGLISH"
+        ),
+    ]

--- a/datashare-spacy-worker/spacy_worker/tests/test_core.py
+++ b/datashare-spacy-worker/spacy_worker/tests/test_core.py
@@ -8,8 +8,8 @@ from icij_common.test_utils import fail_if_exception
 from packaging.version import Version
 
 from spacy_worker.constants import DATA_DIR
-from spacy_worker.core import SpacyProvider
-from spacy_worker.objects import SpacySize
+from spacy_worker.core import SpacyProvider, spacy_ner
+from spacy_worker.objects import Category, NamedEntity, NlpTag, SpacySize
 
 _MODEL_PATH = DATA_DIR.joinpath("models.json")
 _ALL_LANGUAGES = list(json.loads(_MODEL_PATH.read_text()))
@@ -27,17 +27,18 @@ def test_spacy_provider_get_ner(test_spacy_provider: SpacyProvider):
     # When/Then
     msg = f"failed to load ner pipeline for {language}"
     with fail_if_exception(msg):
-        provider.get_ner(language, size=SpacySize.SMALL)
+        provider.get_ner(language, model_size=SpacySize.SMALL)
 
 
 def test_spacy_provider_get_sent_split(test_spacy_provider: SpacyProvider):
     # Given
     language = "en"
+    model_size = SpacySize.SMALL
     provider = test_spacy_provider
     # When/Then
     msg = f"failed to load sentence split pipeline for {language}"
     with fail_if_exception(msg):
-        provider.get_sent_split(language)
+        provider.get_sent_split(language, model_size=model_size)
 
 
 @pytest.mark.skip
@@ -58,3 +59,61 @@ def test_spacy_model_compatibility():
     for model in models.values():
         compatible_versions = version_compatibility[model["model"]]
         assert model["version"] in compatible_versions
+
+
+@pytest.mark.parametrize(
+    "categories,expected_entities",
+    [
+        (
+            [Category.LOC, Category.PER, Category.ORG],
+            [
+                [
+                    NlpTag(start=57, mention="Dan", category=Category.PER),
+                    NlpTag(mention="Paris", category=Category.LOC, start=93),
+                    NlpTag(mention="Paris", category=Category.LOC, start=103),
+                    NlpTag(mention="Intel", category=Category.ORG, start=161),
+                ],
+                [],
+            ],
+        ),
+        (
+            [Category.LOC],
+            [
+                [
+                    NlpTag(mention="Paris", category=Category.LOC, start=93),
+                    NlpTag(mention="Paris", category=Category.LOC, start=103),
+                ],
+                [],
+            ],
+        ),
+    ],
+)
+async def test_spacy_ner(
+    categories: list[Category] | None,
+    expected_entities: list[list[NamedEntity]],
+    text_0: str,
+    text_1: str,
+):
+    # Given
+    texts = [text_0, text_1]
+    language = "en"
+    provider = SpacyProvider(max_languages=1)
+    model_size = SpacySize.SMALL
+    ner = provider.get_ner(language, model_size=model_size)
+    sent_split = provider.get_ner(language, model_size=model_size)
+
+    # When
+    entities = [
+        e
+        async for e in spacy_ner(
+            texts,
+            ner,
+            categories=categories,
+            sent_split=sent_split,
+            n_process=1,
+            batch_size=2,
+        )
+    ]
+
+    # Then
+    assert entities == expected_entities

--- a/datashare-spacy-worker/spacy_worker/tests/test_tasks.py
+++ b/datashare-spacy-worker/spacy_worker/tests/test_tasks.py
@@ -1,23 +1,21 @@
-from typing import List, Optional
-
 import pytest
 import spacy
+from icij_common.es import ESClient, HITS, SOURCE, has_type
+from pydantic import parse_obj_as
 
-from spacy_worker.objects import Category, NamedEntity
-from spacy_worker.tasks import get_n_process, spacy_ner
-
-_doc_0 = """In this first sentence I'm speaking about a person named Dan.
-
-Then later I'm speaking about Paris.
-
-To finish I'm speaking about a company named Intel.
-"""
-
-_doc_1 = "some short document"
+from spacy_worker.objects import (
+    BatchDocument,
+    Category,
+    Document,
+    NamedEntity,
+    SpacySize,
+)
+from spacy_worker.tasks import get_n_process, spacy_ner_task
+from spacy_worker.tests.conftest import TEST_PROJECT
 
 
 @pytest.mark.parametrize(
-    "model,expected_n_process", [("en_core_web_sm", 665), ("en_core_web_trf", 1)]
+    "model,expected_n_process", [("en_core_web_sm", 666), ("en_core_web_trf", 1)]
 )
 def test_get_n_process(model: str, expected_n_process: int):
     # Given
@@ -29,53 +27,111 @@ def test_get_n_process(model: str, expected_n_process: int):
     assert n_process == expected_n_process
 
 
+# TODO: this one would deserve a finer testing due to the multiple corner cases due to
+#  interactions between batch_size, buffer_size and so on
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "categories,expected_entities",
     [
         (
             None,
             [
-                [
-                    NamedEntity(start=57, end=60, category=Category.PER),
-                    NamedEntity(start=93, end=98, category=Category.LOC),
-                    NamedEntity(start=146, end=151, category=Category.ORG),
-                ],
-                [],
+                NamedEntity(
+                    document_id="doc-0",
+                    root_document="root-0",
+                    mention="Dan",
+                    category=Category.PER,
+                    offsets=[57],
+                    extractor_language="ENGLISH",
+                ),
+                NamedEntity(
+                    document_id="doc-0",
+                    root_document="root-0",
+                    mention="Paris",
+                    category=Category.LOC,
+                    offsets=[93, 103],
+                    extractor_language="ENGLISH",
+                ),
+                NamedEntity(
+                    document_id="doc-0",
+                    root_document="root-0",
+                    mention="Intel",
+                    category=Category.ORG,
+                    offsets=[161],
+                    extractor_language="ENGLISH",
+                ),
             ],
         ),
         (
             ["LOCATION", "PERSON", "ORGANIZATION"],
             [
-                [
-                    NamedEntity(start=57, end=60, category=Category.PER),
-                    NamedEntity(start=93, end=98, category=Category.LOC),
-                    NamedEntity(start=146, end=151, category=Category.ORG),
-                ],
-                [],
+                NamedEntity(
+                    document_id="doc-0",
+                    root_document="root-0",
+                    mention="Dan",
+                    category=Category.PER,
+                    offsets=[57],
+                    extractor_language="ENGLISH",
+                ),
+                NamedEntity(
+                    document_id="doc-0",
+                    root_document="root-0",
+                    mention="Paris",
+                    category=Category.LOC,
+                    offsets=[93, 103],
+                    extractor_language="ENGLISH",
+                ),
+                NamedEntity(
+                    document_id="doc-0",
+                    root_document="root-0",
+                    mention="Intel",
+                    category=Category.ORG,
+                    offsets=[161],
+                    extractor_language="ENGLISH",
+                ),
             ],
         ),
         (
             ["LOCATION"],
             [
-                [
-                    NamedEntity(start=93, end=98, category=Category.LOC),
-                ],
-                [],
+                NamedEntity(
+                    document_id="doc-0",
+                    root_document="root-0",
+                    mention="Paris",
+                    category=Category.LOC,
+                    offsets=[93, 103],
+                    extractor_language="ENGLISH",
+                ),
             ],
         ),
     ],
 )
-async def test_spacy_ner_task(
-    categories: Optional[List[str]],
-    expected_entities: List[List[NamedEntity]],
-    app_lifetime_deps,  # pylint: disable=unused-argument
+async def test_spacy_ner_task_int(
+    categories: list[Category] | None,
+    expected_entities: list[NamedEntity],
+    test_es_client: ESClient,
+    populate_es: list[Document],
+    batch_docs: list[BatchDocument],
 ):
+    # pylint: disable=unused-argument
     # Given
-    texts = [_doc_0, _doc_1]
-    language = "en"
+    docs = [d.dict() for d in batch_docs]
+    model_size = SpacySize.SMALL
+    max_length = 62
 
     # When
-    entities = await spacy_ner(texts, language, categories=categories)
+    n_docs = await spacy_ner_task(
+        docs, model_size=model_size, categories=categories, max_length=max_length
+    )
+    body = {"query": has_type(type_field="type", type_value="NamedEntity")}
+    sort = ["offsets:asc"]
+    index_ents = []
+    async for hits in test_es_client.poll_search_pages(
+        index=TEST_PROJECT, body=body, sort=sort
+    ):
+        index_ents += [e[SOURCE] for e in hits[HITS][HITS]]
 
     # Then
-    assert entities == expected_entities
+    assert n_docs == 2
+    index_ents = parse_obj_as(list[NamedEntity], index_ents)
+    assert index_ents == expected_entities

--- a/datashare-spacy-worker/spacy_worker/utils.py
+++ b/datashare-spacy-worker/spacy_worker/utils.py
@@ -1,0 +1,5 @@
+def lower_camel_to_snake_case(s: str):
+    snake = "".join("_" + c.lower() if c.isupper() else c for c in s)
+    if snake.startswith("_"):
+        snake = snake[1:]
+    return snake

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.7'
+
+services:
+  elasticsearch:
+    image: elasticsearch:7.17.25
+    container_name: ds-spacy-test-elasticsearch
+    environment:
+      - discovery.type=single-node
+      - http.port=9200
+    ports:
+      - "9200:9200"
+    healthcheck:
+      test: [ "CMD", "curl", "http://localhost:9200" ]
+      interval: 3s
+      timeout: 1s
+      retries: 10
+      start_period: 20s
+
+  spacy-worker:
+    build:
+      context: .
+      target: worker
+    container_name: ds-spacy-test-worker
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    environment:
+      DS_DOCKER_SPACY_BATCH_SIZE: 1024
+      DS_DOCKER_SPACY_PIPELINE_BATCH_SIZE: 1024
+      DS_DOCKER_SPACY_LOG_LEVEL: DEBUG
+      DS_DOCKER_SPACY_MAX_PROCESSES: 1
+      DS_DOCKER_SPACY_MAX_LANGUAGES_IN_MEMORY: 1
+      DS_DOCKER_ES_ADDRESS: http://elasticsearch:9200
+      ICIJ_WORKER_TYPE: amqp
+      ICIJ_WORKER_RABBITMQ_HOST: host.docker.internal
+      ICIJ_WORKER_RABBITMQ_PORT: 5672
+    extra_hosts:
+      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
# PR description

Update the task to reflect the new batch NLP API of https://github.com/ICIJ/datashare/pull/1597

Documents are now fetched from ES by the worker, and named entities are then saved there.


# Changes

## `datashare-spacy-worker`

### Added
- implemented a `BatchNlp` Spacy worker
